### PR TITLE
Make regexp matching task host little bit less gready

### DIFF
--- a/ansible_parser/tasks.py
+++ b/ansible_parser/tasks.py
@@ -29,7 +29,7 @@ class Tasks:
             self._name = 'Unnamed'
         for task_info in tasks_split[1:]:
             task = {}
-            task_details = re.findall(r'([a-z]+):[ ]+\[(.+)](?::[ ]+(.+))?', task_info, re.IGNORECASE)
+            task_details = re.findall(r'([a-z]+):[ ]+\[([^]]+)](?::[ ]+(.+))?', task_info, re.IGNORECASE)
             task['host'] = task_details[0][1]
             task['status'] = task_details[0][0].lower()
             task['failure_message'] = task_details[0][2]


### PR DESCRIPTION
Having this script:

```
import ansible_parser.play
play = open("out-2022-09-08T22_20_16_00_00.log", "r").read()
ansible = ansible_parser.play.Play(play_output=play)
failures = ansible.failures()
import pprint
pprint.pprint(failures["all"]["Register"]["fatal"][0])
```

and this playbook output (this is contents of that `out-2022-09-08T22_20_16_00_00.log`, error message truncated):

```

PLAY [all] *********************************************************************

TASK [Register] ****************************************************************
fatal: [172.21.38.90]: FAILED! => {"ansible_facts...HTTP error code 500: Internal Server Error)"]}

PLAY RECAP *********************************************************************
172.21.38.90               : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

I was getting (truncated):

```
$ PYTHONPATH=. scripts/investigate-regs-errors.py 
{'failure_message': '',
 'host': '172.21.38.90]: FAILED! => {"ansible_fact...rver Error)"',
 'status': 'fatal'}
```

With the change, I'm getting (truncated):

```
{'failure_message': 'FAILED! => {"ansible_fac...nal Server Error)"]}',
 'host': '172.21.38.90',
 'status': 'fatal'}
```

With the change, tests passed on my machine.