### PR TITLE
Do not fail if parsing task fails

### DIFF
--- a/ansible_parser/tasks.py
+++ b/ansible_parser/tasks.py
@@ -30,6 +30,9 @@ class Tasks:
         for task_info in tasks_split[1:]:
             task = {}
             task_details = re.findall(r'([a-z]+):[ ]+\[([^]]+)](?::[ ]+(.+))?', task_info, re.IGNORECASE)
+            if task_details == []:
+                print(f"WARNING: Failed parsing line '{task_info}'")
+                continue
             task['host'] = task_details[0][1]
             task['status'] = task_details[0][0].lower()
             task['failure_message'] = task_details[0][2]

--- a/test/test_task.py
+++ b/test/test_task.py
@@ -21,3 +21,20 @@ def test_task_info(filename, has_failures, task_name):
 
     assert task.has_failures == has_failures
     assert task._name == task_name
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        'task_with_command.txt',
+        'task_with_debug_msg.txt',
+        'task_with_debug_var.txt',
+    ],
+)
+def test_skipping_debug(filename):
+    with open(f'test/test_data/tasks/{filename}', 'r') as handler:
+        file_content = handler.read()
+    try:
+        play = Tasks(file_content)
+    except IndexError as e:
+        pytest.fail(f'Failed with IndexError: {e}')


### PR DESCRIPTION
For first 2 tasks in this output, parsing fails:

```
PLAY [localhost] ******************************************

TASK [Greet with message] *****************************
ok: [localhost] => {
    "msg": "Hello world"
}

TASK [Greet with variable] *******************************
ok: [localhost] => {
    "greeting": "Hello world"
}

TASK [Greet via command] ******************************
changed: [localhost]

PLAY RECAP *********************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

```
Traceback (most recent call last):
  File "/home/jhutar/Checkouts/satperf/scripts/investigate-regs-errors.py", line 23, in <module>
    playbook = ansible_parser.play.Play(play_output=playbook_output)
  File "/home/jhutar/Checkouts/satperf/ansible_parser/play.py", line 19, in __init__
    self._process_play(play_output)
  File "/home/jhutar/Checkouts/satperf/ansible_parser/play.py", line 45, in _process_play
    tasks: Tasks = Tasks(item)
  File "/home/jhutar/Checkouts/satperf/ansible_parser/tasks.py", line 18, in __init__
    self._process_tasks(tasks_info)
  File "/home/jhutar/Checkouts/satperf/ansible_parser/tasks.py", line 34, in _process_tasks
    task['host'] = task_details[0][1]
IndexError: list index out of range
```

Added a workaround for it and some test.