### PR TITLE
Add method to list all plays and all tasks

### DIFF
--- a/ansible_parser/play.py
+++ b/ansible_parser/play.py
@@ -94,3 +94,11 @@ class Play:
                 if self._plays[play][task].has_failures:
                     failures[play] = self._plays[play][task].failures
         return failures
+
+    def plays(self) -> Dict[str, Dict[str, Dict[str, List[Dict[str, str]]]]]:
+        """
+        Fetches all plays.
+
+        :return: Dictionary containing plays.
+        """
+        return self._plays

--- a/ansible_parser/tasks.py
+++ b/ansible_parser/tasks.py
@@ -1,3 +1,4 @@
+import itertools
 import re
 from typing import Dict, List
 
@@ -70,3 +71,12 @@ class Tasks:
             if task_result_status in OK_STATUS_LIST:
                 del result[self.name][task_result_status]
         return result
+
+    @property
+    def results(self) -> List[Dict[str, str]]:
+        """
+        Fetches all the tasks.
+
+        :return: Tasks.
+        """
+        return list(itertools.chain(*self._task_list.values()))

--- a/test/test_play.py
+++ b/test/test_play.py
@@ -34,3 +34,36 @@ def test_warning(filename, expected):
         file_content = handler.read()
     play = Play(file_content)
     assert play._warnings == expected
+
+
+@pytest.mark.parametrize(
+    "filename,expected",
+    [
+        (
+            'failed_with_warning.txt',
+            1,
+        ),
+        (
+            'multiple_devices.txt',
+            1,
+        ),
+        (
+            'multiple_playbooks.txt',
+            2,
+        ),
+        (
+            'ok_with_warning.txt',
+            1,
+        ),
+        (
+            'simple.txt',
+            1,
+        ),
+    ],
+)
+def test_plays_count(filename, expected):
+    file_content = ''
+    with open(f'test/test_data/playbooks/{filename}', 'r') as handler:
+        file_content = handler.read()
+    play = Play(file_content)
+    assert len(play.plays()) == expected

--- a/test/test_task.py
+++ b/test/test_task.py
@@ -20,4 +20,23 @@ def test_task_info(filename, has_failures, task_name):
     task = Tasks(file_content)
 
     assert task.has_failures == has_failures
-    assert task._name == task_name
+
+
+@pytest.mark.parametrize(
+    "filename,expected_all,expected_failures",
+    [
+        (
+            'task_with_fatal.txt',
+            8,
+            1,
+        ),
+    ],
+)
+def test_task_results_count(filename, expected_all, expected_failures):
+    file_content = ''
+    with open(f'test/test_data/playbooks/{filename}', 'r') as handler:
+        file_content = handler.read()
+    task = Tasks(file_content)
+
+    assert len(task.results) == expected_all
+    assert len(task.failures) == expected_failures


### PR DESCRIPTION
I just needed a way how to traverse through playbook output, so now this is possible:

```
playbook = ansible_parser.play.Play(play_output=playbook_output)
failures = playbook.failures()
for play_name, play_content in playbook.plays().items():
    print(f"play_name = {play_name}")
    for task_name, task_content in play_content.items():
        print(f"task_name = {task_name}")
        for result in task_content.results:
            print(f"host = {result['host']}; status = {result['status']}")
```